### PR TITLE
Add 'GitHub Skills' extracurricular activity (fixes #6)

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -6,6 +6,7 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 - View all available extracurricular activities
 - Sign up for activities
+- New: GitHub Skills activity for practical coding and collaboration (GitHub認定プログラム対応)
 
 ## Getting Started
 
@@ -37,6 +38,19 @@ A super simple FastAPI application that allows students to view and sign up for 
 The application uses a simple data model with meaningful identifiers:
 
 1. **Activities** - Uses activity name as identifier:
+
+### Example Activities
+
+- Chess Club
+- Programming Class
+- Gym Class
+- Soccer Team
+- Basketball Team
+- Art Club
+- Drama Club
+- Math Club
+- Debate Team
+- **GitHub Skills** ← New! Practical coding & collaboration, GitHub Certifications
 
    - Description
    - Schedule

--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Prepare for GitHub Certifications and boost your college applications!",
+        "schedule": "Thursdays, 4:00 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
This PR adds the new 'GitHub Skills' extracurricular activity to the in-memory database and updates the README to reflect the addition. This addresses Issue #6, enabling students to register for the new activity as announced by the principal.